### PR TITLE
Update Facebook OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ This Next.js app demonstrates Facebook Login and fetching/publishing posts using
 ## Setup
 
 1. Copy `.env.example` to `.env.local` and fill in `FACEBOOK_APP_ID`, `FACEBOOK_APP_SECRET` and `NEXT_PUBLIC_BASE_URL`.
-2. Install dependencies:
+2. Make sure the Facebook app is in development mode and that you're using a **test user**.
+   The login request now asks for the following scopes so posting works:
+   `email`, `pages_read_engagement`, `pages_manage_posts`, and `publish_to_groups`.
+3. Install dependencies:
    ```bash
    npm install
    ```
-3. Run development server:
+4. Run development server:
    ```bash
    npm run dev
    ```

--- a/src/app/api/auth/facebook/route.ts
+++ b/src/app/api/auth/facebook/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server'
 
 export async function GET() {
-	const facebookAuthUrl = `https://www.facebook.com/v18.0/dialog/oauth?client_id=${process.env.FACEBOOK_APP_ID}&redirect_uri=${encodeURIComponent(
-		`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/auth/facebook/callback`
-	)}&scope=email&response_type=code&state=random_state`
+  const facebookAuthUrl = `https://www.facebook.com/v18.0/dialog/oauth?client_id=${process.env.FACEBOOK_APP_ID}&redirect_uri=${encodeURIComponent(
+                `${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/auth/facebook/callback`
+        )}&scope=email,pages_read_engagement,pages_manage_posts,publish_to_groups&response_type=code&state=random_state`
 
 	return NextResponse.redirect(facebookAuthUrl)
 }


### PR DESCRIPTION
## Summary
- request publishing-related permissions during Facebook OAuth
- document that the app must run with a test user and the new permissions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684040eb000c8326882b12a0a8b597c6