### PR TITLE
Refactor Facebook auth and add token validation

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,6 +1,8 @@
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
+import { FacebookService } from '@/services/facebook.service'
+
 export async function GET() {
   const cookieStore = await cookies()
   const userCookie = cookieStore.get('user')
@@ -15,11 +17,17 @@ export async function GET() {
     return NextResponse.json({ error: 'Invalid cookie' }, { status: 400 })
   }
 
+  const facebookService = new FacebookService()
+  const validation = await facebookService.validateAccessToken(token)
+  if (!validation.isValid) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+  }
+
   const res = await fetch(
     `https://graph.facebook.com/v23.0/me/posts?fields=message,created_time,id,story,type&limit=10&access_token=${token}`
   )
 
   const data = await res.json()
-  console.log('API Response Data:', JSON.stringify(data, null, 2))
   return NextResponse.json(data)
 }
+

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 import { Navbar } from '@/components/layout/navbar/Navbar'
+import { FacebookService } from '@/services/facebook.service'
 
 export default async function DashboardLayout({
   children
@@ -15,12 +16,27 @@ export default async function DashboardLayout({
     redirect('/login')
   }
 
-  let user
+  let accessToken = ''
   try {
-    user = JSON.parse(userCookie.value)
+    accessToken = JSON.parse(userCookie.value).accessToken
   } catch {
     redirect('/login')
   }
+
+  const facebookService = new FacebookService()
+  const validation = await facebookService.validateAccessToken(accessToken)
+
+  if (!validation.isValid) {
+    redirect('/login')
+  }
+
+  let user
+  try {
+    user = await facebookService.getUserProfile(accessToken)
+  } catch {
+    redirect('/login')
+  }
+
   return (
     <div className='min-h-screen'>
       <Navbar user={user} />

--- a/src/components/layout/navbar/Navbar.tsx
+++ b/src/components/layout/navbar/Navbar.tsx
@@ -6,10 +6,10 @@ import type { FC } from 'react'
 
 import { Button } from '@/ui/Button'
 
-import type { IUser } from '@/entities/user.entity'
+import type { IProfile } from '@/entities/profile.entity'
 
 interface IProps {
-  user: IUser
+  user: IProfile
 }
 
 export const Navbar: FC<IProps> = ({ user }) => {

--- a/src/entities/profile.entity.ts
+++ b/src/entities/profile.entity.ts
@@ -1,0 +1,6 @@
+export interface IProfile {
+  id: string
+  name: string
+  email: string | null
+  photo: string | null
+}

--- a/src/services/facebook.service.ts
+++ b/src/services/facebook.service.ts
@@ -1,0 +1,96 @@
+import type { IProfile } from '@/entities/profile.entity'
+
+export interface ITokenValidationResult {
+  isValid: boolean
+  userId?: string
+  expiresAt?: number
+  errorMessage?: string
+}
+
+interface DebugTokenData {
+  is_valid: boolean
+  user_id: string
+  expires_at: number
+}
+
+interface GraphApiError {
+  error: {
+    message: string
+    type: string
+    code: number
+    fbtrace_id: string
+  }
+}
+
+interface DebugTokenSuccess {
+  data: DebugTokenData
+}
+
+type DebugTokenResponse = DebugTokenSuccess | GraphApiError
+
+interface PictureData {
+  url: string
+}
+
+interface ProfileSuccess {
+  id: string
+  name: string
+  email?: string
+  picture?: {
+    data?: PictureData
+  }
+}
+
+type ProfileResponse = ProfileSuccess | GraphApiError
+
+export class FacebookService {
+  private readonly graphApiBaseUrl = 'https://graph.facebook.com'
+
+  async validateAccessToken(accessToken: string): Promise<ITokenValidationResult> {
+    try {
+      const res = await fetch(
+        `${this.graphApiBaseUrl}/debug_token?input_token=${accessToken}&access_token=${process.env.FACEBOOK_APP_ID}|${process.env.FACEBOOK_APP_SECRET}`
+      )
+      const data: DebugTokenResponse = await res.json()
+
+      if (!res.ok || 'error' in data) {
+        return {
+          isValid: false,
+          errorMessage: 'error' in data ? data.error.message : 'Invalid response'
+        }
+      }
+
+      return {
+        isValid: data.data.is_valid,
+        userId: data.data.user_id,
+        expiresAt: data.data.expires_at
+      }
+    } catch (error) {
+      console.error('validateAccessToken error:', error)
+      return { isValid: false, errorMessage: 'Failed to validate token' }
+    }
+  }
+
+  async getUserProfile(accessToken: string): Promise<IProfile> {
+    try {
+      const res = await fetch(
+        `${this.graphApiBaseUrl}/me?fields=id,name,email,picture&access_token=${accessToken}`
+      )
+      const data: ProfileResponse = await res.json()
+
+      if (!res.ok || 'error' in data) {
+        throw new Error('error' in data ? data.error.message : 'Profile request failed')
+      }
+
+      return {
+        id: data.id,
+        name: data.name,
+        email: data.email ?? null,
+        photo: data.picture?.data?.url ?? null
+      }
+    } catch (error) {
+      console.error('getUserProfile error:', error)
+      throw new Error('Unable to fetch profile')
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `FacebookService` for Graph API interactions
- fetch profile data through the API instead of cookies
- validate Facebook access tokens before use
- update navbar to accept the new profile type
- add `IProfile` entity for strongly typed profile data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684135c5f7408326aed9b43f94f90f88